### PR TITLE
Add sans-serif as fallback for OSP-DIN

### DIFF
--- a/lgm2014/css/expound.css
+++ b/lgm2014/css/expound.css
@@ -137,7 +137,7 @@ a:hover {
 }
 .navigation-main {
   background: #0044aa;
-  font-family: 'OSP-DIN';
+  font-family: 'OSP-DIN', sans-serif;
   font-weight: normal;
   font-style: normal;
   font-size: 16px;


### PR DESCRIPTION
OSP-DIN is missing some needed glyphs like '&'. Using a fallback of sans-serif looks better than serif which seems to be default for many people.
